### PR TITLE
modify jquery css head insert

### DIFF
--- a/iotas/www/apps/colorwheel/colorwheel.js
+++ b/iotas/www/apps/colorwheel/colorwheel.js
@@ -20,7 +20,8 @@ function colorwheel() {
 	
 	function appStart() {
 		console.log("colorwheel.appStart");
-		$("head").append('<link rel="stylesheet" href="colorwheel.css" />');
+		var cssPathFromBase = $('head base').attr('href') + "colorwheel.css";
+		$("head").append('<link rel="stylesheet" type="text/css" href="' + cssPathFromBase + '" />');
 		setCanvasImage()
 	}
 	

--- a/iotas/www/apps/colorwheel/colorwheel.js
+++ b/iotas/www/apps/colorwheel/colorwheel.js
@@ -38,6 +38,8 @@ function colorwheel() {
 			var wh = $('.selector').innerWidth();
 			$('#canvas').attr('width', wh);
 			$('#canvas').attr('height', wh);
+			$('#canvas').css('-touch-action','none');
+			$('#canvas').css('-ms-touch-action','none');
 			theApp.context.drawImage(canvasImage, x, y, wh, wh);
 		};
 		canvasImage.src="colorwheel.png";


### PR DESCRIPTION
jQuery Mobile and jQuery are interesting beasts. 

In the jQuery Mobile app, if you insert (via jQuery) a new css, on some browsers it works. On IE10 it doesn't. What happens is that IE10 attempts to reload the css without taking the <base> into consideration. And <base> is used extensively by jQuery Mobile to separate apps.

This modification gets the <base> from the rendered jQuery Mobile page, prepends this to the .css and then uses jQuery to insert the full path into the header. 

IE10 (Windows Phone) is happy; have regression tested with Chrome & IE11 (not on phone OK)
