### PR TITLE
Fixes for countdown app

### DIFF
--- a/iotas/www/apps/countdown/countdown.js
+++ b/iotas/www/apps/countdown/countdown.js
@@ -71,10 +71,10 @@ function countdown() {
 			} else {
 				if (t <= 30) {
 					console.log("flashing");
-					if ((t % 2) == 0) {
-						this.currentLight.gradient(255, 0, 0, 0, 0, 0, 45);
+					if ((t % 2) === 0) {
+						this.currentLight.gradient(255, 0, 0, 105, 0, 0, 25);
 					} else {
-						this.currentLight.gradient(0, 0, 0, 255, 0, 0, 45);
+						this.currentLight.gradient(105, 0, 0, 255, 0, 0, 25);
 					}
 				}
 			}
@@ -88,7 +88,7 @@ function countdown() {
 	  {
 		clearInterval(theApp.counter);
 		theApp.drawCountdown();
-		this.currentLight.gradient(255, 0, 0, 0, 0, 0, 45);
+		this.currentLight.gradient(255, 0, 0, 0, 0, 0, 128);
 		return;
 	  }
 	 theApp.fireLight(theApp.count);


### PR DESCRIPTION
Two issues fixed:
1) red lights no longer stutter during the red flashing phase of countdown
2) red lights turn off completely after countdown completes

Details:
1) gradients could not complete within 1sec, causing clashing gradients. Fixed by pulsing between bright red and a darker red, rather than full black; and reducing the number of steps.

2) gradients need at least half as many steps as the brightest value to turn off to black/off (I've commented with details and test cases at http://support.moorescloud.com/2013/12/known-bugs/). Fix here was to increase the final gradient to 128 steps. This also differentiates the countdown pulses from the last fadeout.
